### PR TITLE
[codex] Fix playback cleanup and error reporting

### DIFF
--- a/cmd/player/main.go
+++ b/cmd/player/main.go
@@ -30,8 +30,11 @@ type model struct {
 }
 
 type (
-	songPlayingMsg string
 	errorMsg       error
+	loadedTrackMsg struct {
+		track    track.Track
+		previous beep.StreamSeekCloser
+	}
 )
 
 type tickMsg time.Time
@@ -59,27 +62,36 @@ func (m *model) updatePlaybackLoop() error {
 }
 
 func (m *model) playSongCmd(path string) tea.Cmd {
+	previous := m.playing.Control.Source
+
 	return func() tea.Msg {
 		f, err := os.Open(path)
 		if err != nil {
-			log.Println("Error opening file:", err)
-			return nil
+			return errorMsg(fmt.Errorf("open %s: %w", filepath.Base(path), err))
 		}
 		streamer, format, err := mp3.Decode(f)
 		if err != nil {
-			log.Println("Error decoding file:", err)
-			return nil
+			_ = f.Close()
+			return errorMsg(fmt.Errorf("decode %s: %w", filepath.Base(path), err))
 		}
 		title := filepath.Base(path)
 		length := format.SampleRate.D(streamer.Len())
-		track := track.New(streamer, &format, title, length)
-
-		resample := beep.Resample(4, format.SampleRate, m.sampleRate, track.Control.Ctrl)
-		speaker.Clear()
-		speaker.Play(resample)
-
-		return track
+		return loadedTrackMsg{
+			track:    track.New(streamer, &format, title, length),
+			previous: previous,
+		}
 	}
+}
+
+func (m *model) stopPlayback() error {
+	if m.playing.Control.Source == nil {
+		return nil
+	}
+
+	speaker.Clear()
+	err := m.playing.Control.Source.Close()
+	m.playing = track.Track{}
+	return err
 }
 
 func tickCmd() tea.Cmd {
@@ -131,6 +143,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch {
 		case key.Matches(msg, m.help.Keys().Quit):
+			if err := m.stopPlayback(); err != nil {
+				log.Printf("error closing active track: %v", err)
+			}
 			return m, tea.Quit
 		case key.Matches(msg, m.help.Keys().PlayPause):
 			if m.playing.Control.Ctrl == nil {
@@ -161,11 +176,6 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 
 		}
-	case songPlayingMsg:
-		m.playing.Title = string(msg)
-		m.err = nil
-		return m, nil
-
 	case errorMsg:
 		m.err = msg
 		return m, nil
@@ -174,9 +184,21 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loadingDirectory = false
 		return m, nil
 
-	case track.Track:
-		m.playing = msg
+	case loadedTrackMsg:
+		speaker.Clear()
+		if msg.previous != nil {
+			if err := msg.previous.Close(); err != nil {
+				log.Printf("error closing previous track: %v", err)
+			}
+		}
+
+		m.playing = msg.track
 		m.playing.Control.Paused = false
+		m.err = nil
+
+		resample := beep.Resample(4, m.playing.Format.SampleRate, m.sampleRate, m.playing.Control.Ctrl)
+		speaker.Play(resample)
+
 		return m, tickCmd()
 
 	case tickMsg:

--- a/internal/control/control.go
+++ b/internal/control/control.go
@@ -6,11 +6,11 @@ import (
 
 type Control struct {
 	*beep.Ctrl
-	Source beep.StreamSeeker
+	Source beep.StreamSeekCloser
 	Loop   bool
 }
 
-func New(source beep.StreamSeeker) Control {
+func New(source beep.StreamSeekCloser) Control {
 	return Control{
 		Ctrl:   &beep.Ctrl{Streamer: source, Paused: false},
 		Source: source,

--- a/internal/track/track.go
+++ b/internal/track/track.go
@@ -44,7 +44,7 @@ func (t Track) String() string {
 }
 
 func New(
-	streamer beep.StreamSeeker,
+	streamer beep.StreamSeekCloser,
 	format *beep.Format,
 	title string,
 	length time.Duration,


### PR DESCRIPTION
## What changed
- surface file open and MP3 decode failures in the TUI instead of only logging them to the terminal
- close the previous decoded stream when switching tracks and close the active stream on quit
- carry the decoded source as a `beep.StreamSeekCloser` through the control and track types so playback resources can be released correctly

## Why
The player was leaking decoder/file handles across track changes and process shutdown, and playback failures were effectively invisible in the app even though the UI already had an error state.

## Impact
Users now see playback load failures directly in the player UI, and repeated track changes no longer leave old MP3 streams open.

## Root cause
`mp3.Decode` returns a closable stream, but the app only stored it as a seeker and never closed the previous source. The load command also logged errors and returned `nil`, so the update loop never received a message to display.

## Validation
- `go test ./...`
- manual TUI run with `go run ./cmd/player`
