### PR TITLE
Add playback queue and stabilize player layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 tmp*
-player*
+/player*

--- a/cmd/player/main.go
+++ b/cmd/player/main.go
@@ -23,9 +23,12 @@ import (
 
 const (
 	defaultWindowWidth     = 80
+	defaultWindowHeight    = 24
 	queuePanelContentWidth = 36
+	minQueuePanelWidth     = 16
 	queuePanelGap          = 2
 	minLeftPaneWidth       = 20
+	minTopPaneHeight       = 4
 )
 
 type focusMode int
@@ -45,6 +48,7 @@ type model struct {
 	sampleRate  beep.SampleRate
 	help        help.HelpUI
 	width       int
+	height      int
 	err         error
 }
 
@@ -153,6 +157,27 @@ func (m *model) moveQueueCursor(delta int) {
 	m.clampQueueCursor()
 }
 
+func (m *model) ensureFocusablePane() {
+	if m.focus == focusQueue && len(m.queue) == 0 {
+		m.focus = focusTracks
+	}
+}
+
+func (m *model) focusNextPane() {
+	if m.focus == focusQueue {
+		m.focus = focusTracks
+		return
+	}
+
+	if len(m.queue) == 0 {
+		m.focus = focusTracks
+		return
+	}
+
+	m.focus = focusQueue
+	m.clampQueueCursor()
+}
+
 func (m *model) dequeueSelected() (queuedTrack, bool) {
 	if len(m.queue) == 0 {
 		return queuedTrack{}, false
@@ -162,6 +187,7 @@ func (m *model) dequeueSelected() (queuedTrack, bool) {
 	selected := m.queue[m.queueCursor]
 	m.queue = append(m.queue[:m.queueCursor], m.queue[m.queueCursor+1:]...)
 	m.clampQueueCursor()
+	m.ensureFocusablePane()
 	return selected, true
 }
 
@@ -176,6 +202,7 @@ func (m *model) dequeueNext() (queuedTrack, bool) {
 		m.queueCursor--
 	}
 	m.clampQueueCursor()
+	m.ensureFocusablePane()
 	return next, true
 }
 
@@ -191,59 +218,144 @@ func (m model) isPlaying() bool {
 	return m.playing.Control.Ctrl != nil && m.playing.Control.Source != nil
 }
 
-func queueLine(s string) string {
-	return lipgloss.NewStyle().MaxWidth(queuePanelContentWidth).Render(s)
+func boundedWidth(width int) int {
+	if width < 0 {
+		return 0
+	}
+	return width
 }
 
-func (m *model) queueView() string {
+func trackPanelStyle(focused bool) lipgloss.Style {
 	borderColor := lipgloss.Color("#89dceb")
-	if m.focus == focusQueue {
+	if focused {
 		borderColor = lipgloss.Color("#f5c2e7")
 	}
 
-	queueStyle := lipgloss.NewStyle().
-		Width(queuePanelContentWidth).
-		MaxWidth(queuePanelContentWidth).
+	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(borderColor).
 		Padding(0, 1)
+}
 
-	lines := []string{"Queue"}
+func queuePanelStyle(focused bool, width int) lipgloss.Style {
+	borderColor := lipgloss.Color("#89dceb")
+	if focused {
+		borderColor = lipgloss.Color("#f5c2e7")
+	}
+
+	return lipgloss.NewStyle().
+		Width(boundedWidth(width)).
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(borderColor).
+		Padding(0, 1)
+}
+
+func playerHelpPanelStyle() lipgloss.Style {
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("#94e2d5")).
+		Padding(0, 1)
+}
+
+func (m *model) queueView() string {
+	return m.queueViewWithWidth(queuePanelContentWidth)
+}
+
+func queueLine(width int, s string) string {
+	return ansi.Truncate(s, boundedWidth(width), "")
+}
+
+func (m *model) queueViewWithWidth(width int) string {
+	queueStyle := queuePanelStyle(m.focus == focusQueue, width)
+	contentWidth := boundedWidth(width - queueStyle.GetHorizontalPadding())
+
+	lines := []string{queueLine(contentWidth, "Queue")}
 	if m.playing.Title != "" {
 		lines = append(lines,
 			"",
-			"Playing",
-			queueLine("  "+m.playing.Title),
+			queueLine(contentWidth, "Playing"),
+			queueLine(contentWidth, "  "+m.playing.Title),
 		)
 	}
 
-	lines = append(lines, "", "Up Next")
+	lines = append(lines, "", queueLine(contentWidth, "Up Next"))
 	if len(m.queue) == 0 {
-		lines = append(lines, "  (empty)")
+		lines = append(lines, queueLine(contentWidth, "  (empty)"))
 	} else {
 		for i, item := range m.queue {
 			prefix := "  "
 			if m.focus == focusQueue && i == m.queueCursor {
 				prefix = "> "
 			}
-			lines = append(lines, queueLine(fmt.Sprintf("%s%d. %s", prefix, i+1, item.title)))
+			lines = append(lines, queueLine(contentWidth, fmt.Sprintf("%s%d. %s", prefix, i+1, item.title)))
 		}
 	}
 
 	return queueStyle.Render(strings.Join(lines, "\n"))
 }
 
-func (m model) leftPaneWidth(queue string) int {
-	width := m.width
-	if width <= 0 {
-		width = defaultWindowWidth
+func (m model) windowWidth() int {
+	if m.width > 0 {
+		return m.width
+	}
+	return defaultWindowWidth
+}
+
+func (m model) windowHeight() int {
+	if m.height > 0 {
+		return m.height
+	}
+	return defaultWindowHeight
+}
+
+type topPaneSizing struct {
+	leftWidth  int
+	queueWidth int
+	gap        int
+}
+
+func (m model) topPaneSizing() topPaneSizing {
+	trackBorderWidth := trackPanelStyle(m.focus == focusTracks).GetHorizontalBorderSize()
+	queueBorderWidth := queuePanelStyle(m.focus == focusQueue, queuePanelContentWidth).GetHorizontalBorderSize()
+
+	gap := queuePanelGap
+	if widthAfterBorders := m.windowWidth() - trackBorderWidth - queueBorderWidth; widthAfterBorders < gap {
+		gap = boundedWidth(widthAfterBorders)
 	}
 
-	leftWidth := width - lipgloss.Width(queue) - queuePanelGap
-	if leftWidth < minLeftPaneWidth {
+	availableWidth := boundedWidth(m.windowWidth() - trackBorderWidth - queueBorderWidth - gap)
+	queueWidth := queuePanelContentWidth
+	if availableWidth < minLeftPaneWidth+queueWidth {
+		queueWidth = availableWidth - minLeftPaneWidth
+	}
+	if queueWidth < minQueuePanelWidth {
+		queueWidth = minQueuePanelWidth
+	}
+	if queueWidth > availableWidth {
+		queueWidth = availableWidth
+	}
+
+	return topPaneSizing{
+		leftWidth:  availableWidth - queueWidth,
+		queueWidth: queueWidth,
+		gap:        gap,
+	}
+}
+
+func (m model) playerHelpPanelWidth() int {
+	width := m.windowWidth() - playerHelpPanelStyle().GetHorizontalBorderSize()
+	if width < minLeftPaneWidth {
 		return minLeftPaneWidth
 	}
-	return leftWidth
+	return width
+}
+
+func (m model) playerHelpContentWidth() int {
+	width := m.playerHelpPanelWidth() - playerHelpPanelStyle().GetHorizontalPadding()
+	if width < minLeftPaneWidth {
+		return minLeftPaneWidth
+	}
+	return width
 }
 
 func truncateBlock(s string, width int) string {
@@ -254,6 +366,18 @@ func truncateBlock(s string, width int) string {
 	lines := strings.Split(s, "\n")
 	for i, line := range lines {
 		lines[i] = ansi.Truncate(line, width, "")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func truncateBlockHeight(s string, height int) string {
+	if height <= 0 {
+		return ""
+	}
+
+	lines := strings.Split(s, "\n")
+	if len(lines) > height {
+		lines = lines[:height]
 	}
 	return strings.Join(lines, "\n")
 }
@@ -275,19 +399,13 @@ func (m model) helpFocus() help.FocusArea {
 	return help.FocusTracks
 }
 
-func (m model) View() string {
-	if m.help.GetshowHelp() {
-		var b strings.Builder
-		b.WriteString("Help — press ? to close\n\n")
-		b.WriteString(m.help.ListView(m.helpFocus()))
-		return b.String()
-	}
-	var leftPane strings.Builder
-	leftPane.WriteString(m.tracks.View())
-	leftPane.WriteString("\n")
-	statusStyle := lipgloss.NewStyle().Padding(0, 1)
+func (m model) playerHelpView() string {
+	contentWidth := m.playerHelpContentWidth()
+	statusStyle := lipgloss.NewStyle().Padding(0, 1).MaxWidth(contentWidth)
+
+	lines := make([]string, 0, 4)
 	if m.err != nil {
-		leftPane.WriteString(statusStyle.Render(fmt.Sprintf("❌ Error: %v", m.err)))
+		lines = append(lines, statusStyle.Render(fmt.Sprintf("❌ Error: %v", m.err)))
 	} else if m.playing.Title != "" {
 		statusText := fmt.Sprintf("🎵 Now Playing: %s", m.playing.Title)
 		if m.playing.Control.Paused {
@@ -296,30 +414,61 @@ func (m model) View() string {
 		if m.playing.Control.Loop {
 			statusText += "  🔁 Loop On"
 		}
-		leftPane.WriteString(statusStyle.Render(statusText))
-		leftPane.WriteString(statusStyle.Render(
-			"\n" +
-				m.playing.String()))
+		lines = append(lines, statusStyle.Render(statusText))
+		lines = append(lines, statusStyle.Render(m.playing.String()))
 	} else {
-		leftPane.WriteString(statusStyle.Render("Select an MP3 file to play."))
+		lines = append(lines, statusStyle.Render("Select an MP3 file to play."))
 	}
-	helpView := m.help.View(m.helpFocus())
-	leftPane.WriteString("\n" + helpView)
 
-	queue := m.queueView()
-	leftWidth := m.leftPaneWidth(queue)
-	leftBorderColor := lipgloss.Color("#89dceb")
-	if m.focus == focusTracks {
-		leftBorderColor = lipgloss.Color("#f5c2e7")
+	if helpView := m.help.ViewWithWidth(m.helpFocus(), contentWidth); helpView != "" {
+		lines = append(lines, helpView)
 	}
-	left := lipgloss.NewStyle().
-		Width(leftWidth).
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(leftBorderColor).
-		Padding(0, 1).
-		Render(truncateBlock(leftPane.String(), leftWidth))
 
-	return lipgloss.JoinHorizontal(lipgloss.Top, left, strings.Repeat(" ", queuePanelGap), queue)
+	return playerHelpPanelStyle().
+		Width(m.playerHelpPanelWidth()).
+		Render(truncateBlock(strings.Join(lines, "\n"), contentWidth))
+}
+
+func (m model) topPaneHeight(bottom string) int {
+	height := m.windowHeight() - lipgloss.Height(bottom)
+	if height < minTopPaneHeight {
+		return minTopPaneHeight
+	}
+	return height
+}
+
+func (m model) tracksViewHeight(topHeight int) int {
+	height := topHeight - trackPanelStyle(m.focus == focusTracks).GetVerticalFrameSize() - 1
+	if height < 0 {
+		return 0
+	}
+	return height
+}
+
+func (m model) View() string {
+	if m.help.GetshowHelp() {
+		var b strings.Builder
+		b.WriteString("Help — press ? to close\n\n")
+		b.WriteString(m.help.ListView(m.helpFocus()))
+		return b.String()
+	}
+	bottom := m.playerHelpView()
+	topHeight := m.topPaneHeight(bottom)
+
+	sizing := m.topPaneSizing()
+	queue := m.queueViewWithWidth(sizing.queueWidth)
+	trackStyle := trackPanelStyle(m.focus == focusTracks)
+	leftContentWidth := boundedWidth(sizing.leftWidth - trackStyle.GetHorizontalPadding())
+	var leftPane strings.Builder
+	leftPane.WriteString(m.tracks.ViewWithHeight(m.tracksViewHeight(topHeight)))
+	left := trackStyle.
+		Width(sizing.leftWidth).
+		Render(truncateBlock(leftPane.String(), leftContentWidth))
+
+	top := lipgloss.JoinHorizontal(lipgloss.Top, left, strings.Repeat(" ", sizing.gap), queue)
+	top = truncateBlock(top, m.windowWidth())
+	top = truncateBlockHeight(top, topHeight)
+	return lipgloss.JoinVertical(lipgloss.Left, top, bottom)
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -348,12 +497,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 
 		case key.Matches(msg, m.help.Keys().Global.FocusNext):
-			if m.focus == focusQueue {
-				m.focus = focusTracks
-			} else {
-				m.focus = focusQueue
-				m.clampQueueCursor()
-			}
+			m.focusNextPane()
 			return m, nil
 
 		case key.Matches(msg, m.help.Keys().Global.Loop):
@@ -413,6 +557,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
+		m.height = msg.Height
 
 	case loadedTrackMsg:
 		speaker.Clear()

--- a/cmd/player/main.go
+++ b/cmd/player/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/kjloveless/tmp/internal/help"
 	"github.com/kjloveless/tmp/internal/track"
 
@@ -20,19 +21,43 @@ import (
 	"github.com/gopxl/beep/v2/speaker"
 )
 
+const (
+	defaultWindowWidth     = 80
+	queuePanelContentWidth = 36
+	queuePanelGap          = 2
+	minLeftPaneWidth       = 20
+)
+
+type focusMode int
+
+const (
+	focusTracks focusMode = iota
+	focusQueue
+)
+
 type model struct {
-	playing          track.Track
-	filepicker       filepicker.Model
-	sampleRate       beep.SampleRate
-	help             help.HelpUI
-	loadingDirectory bool
-	err              error
+	playing     track.Track
+	playingPath string
+	queue       []queuedTrack
+	queueCursor int
+	tracks      tracksComponent
+	focus       focusMode
+	sampleRate  beep.SampleRate
+	help        help.HelpUI
+	width       int
+	err         error
+}
+
+type queuedTrack struct {
+	path  string
+	title string
 }
 
 type (
 	errorMsg       error
 	loadedTrackMsg struct {
 		track    track.Track
+		path     string
 		previous beep.StreamSeekCloser
 	}
 )
@@ -78,6 +103,7 @@ func (m *model) playSongCmd(path string) tea.Cmd {
 		length := format.SampleRate.D(streamer.Len())
 		return loadedTrackMsg{
 			track:    track.New(streamer, &format, title, length),
+			path:     path,
 			previous: previous,
 		}
 	}
@@ -91,7 +117,145 @@ func (m *model) stopPlayback() error {
 	speaker.Clear()
 	err := m.playing.Control.Source.Close()
 	m.playing = track.Track{}
+	m.playingPath = ""
 	return err
+}
+
+func (m *model) enqueueSelected() bool {
+	path, ok := m.tracks.selectedFilePath()
+	if !ok {
+		return false
+	}
+
+	m.queue = append(m.queue, queuedTrack{
+		path:  path,
+		title: filepath.Base(path),
+	})
+	return true
+}
+
+func (m *model) clampQueueCursor() {
+	if len(m.queue) == 0 {
+		m.queueCursor = 0
+		return
+	}
+
+	switch {
+	case m.queueCursor < 0:
+		m.queueCursor = 0
+	case m.queueCursor >= len(m.queue):
+		m.queueCursor = len(m.queue) - 1
+	}
+}
+
+func (m *model) moveQueueCursor(delta int) {
+	m.queueCursor += delta
+	m.clampQueueCursor()
+}
+
+func (m *model) dequeueSelected() (queuedTrack, bool) {
+	if len(m.queue) == 0 {
+		return queuedTrack{}, false
+	}
+
+	m.clampQueueCursor()
+	selected := m.queue[m.queueCursor]
+	m.queue = append(m.queue[:m.queueCursor], m.queue[m.queueCursor+1:]...)
+	m.clampQueueCursor()
+	return selected, true
+}
+
+func (m *model) dequeueNext() (queuedTrack, bool) {
+	if len(m.queue) == 0 {
+		return queuedTrack{}, false
+	}
+
+	next := m.queue[0]
+	m.queue = m.queue[1:]
+	if m.queueCursor > 0 {
+		m.queueCursor--
+	}
+	m.clampQueueCursor()
+	return next, true
+}
+
+func (m *model) playNextQueuedCmd() (tea.Cmd, bool) {
+	next, ok := m.dequeueNext()
+	if !ok {
+		return nil, false
+	}
+	return m.playSongCmd(next.path), true
+}
+
+func (m model) isPlaying() bool {
+	return m.playing.Control.Ctrl != nil && m.playing.Control.Source != nil
+}
+
+func queueLine(s string) string {
+	return lipgloss.NewStyle().MaxWidth(queuePanelContentWidth).Render(s)
+}
+
+func (m *model) queueView() string {
+	borderColor := lipgloss.Color("#89dceb")
+	if m.focus == focusQueue {
+		borderColor = lipgloss.Color("#f5c2e7")
+	}
+
+	queueStyle := lipgloss.NewStyle().
+		Width(queuePanelContentWidth).
+		MaxWidth(queuePanelContentWidth).
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(borderColor).
+		Padding(0, 1)
+
+	lines := []string{"Queue"}
+	if m.playing.Title != "" {
+		lines = append(lines,
+			"",
+			"Playing",
+			queueLine("  "+m.playing.Title),
+		)
+	}
+
+	lines = append(lines, "", "Up Next")
+	if len(m.queue) == 0 {
+		lines = append(lines, "  (empty)")
+	} else {
+		for i, item := range m.queue {
+			prefix := "  "
+			if m.focus == focusQueue && i == m.queueCursor {
+				prefix = "> "
+			}
+			lines = append(lines, queueLine(fmt.Sprintf("%s%d. %s", prefix, i+1, item.title)))
+		}
+	}
+
+	return queueStyle.Render(strings.Join(lines, "\n"))
+}
+
+func (m model) leftPaneWidth(queue string) int {
+	width := m.width
+	if width <= 0 {
+		width = defaultWindowWidth
+	}
+
+	leftWidth := width - lipgloss.Width(queue) - queuePanelGap
+	if leftWidth < minLeftPaneWidth {
+		return minLeftPaneWidth
+	}
+	return leftWidth
+}
+
+func truncateBlock(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = ansi.Truncate(line, width, "")
+	}
+	return strings.Join(lines, "\n")
 }
 
 func tickCmd() tea.Cmd {
@@ -101,23 +265,29 @@ func tickCmd() tea.Cmd {
 }
 
 func (m model) Init() tea.Cmd {
-	return m.filepicker.Init()
+	return m.tracks.Init()
+}
+
+func (m model) helpFocus() help.FocusArea {
+	if m.focus == focusQueue {
+		return help.FocusQueue
+	}
+	return help.FocusTracks
 }
 
 func (m model) View() string {
-	var builder strings.Builder
-
 	if m.help.GetshowHelp() {
 		var b strings.Builder
 		b.WriteString("Help — press ? to close\n\n")
-		b.WriteString(m.help.ListView())
+		b.WriteString(m.help.ListView(m.helpFocus()))
 		return b.String()
 	}
-	builder.WriteString(m.filepicker.View())
-	builder.WriteString("\n")
+	var leftPane strings.Builder
+	leftPane.WriteString(m.tracks.View())
+	leftPane.WriteString("\n")
 	statusStyle := lipgloss.NewStyle().Padding(0, 1)
 	if m.err != nil {
-		builder.WriteString(statusStyle.Render(fmt.Sprintf("❌ Error: %v", m.err)))
+		leftPane.WriteString(statusStyle.Render(fmt.Sprintf("❌ Error: %v", m.err)))
 	} else if m.playing.Title != "" {
 		statusText := fmt.Sprintf("🎵 Now Playing: %s", m.playing.Title)
 		if m.playing.Control.Paused {
@@ -126,29 +296,50 @@ func (m model) View() string {
 		if m.playing.Control.Loop {
 			statusText += "  🔁 Loop On"
 		}
-		builder.WriteString(statusStyle.Render(statusText))
-		builder.WriteString(statusStyle.Render(
+		leftPane.WriteString(statusStyle.Render(statusText))
+		leftPane.WriteString(statusStyle.Render(
 			"\n" +
 				m.playing.String()))
 	} else {
-		builder.WriteString(statusStyle.Render("Select an MP3 file to play."))
+		leftPane.WriteString(statusStyle.Render("Select an MP3 file to play."))
 	}
-	helpView := m.help.View()
-	builder.WriteString("\n" + helpView)
-	return builder.String()
+	helpView := m.help.View(m.helpFocus())
+	leftPane.WriteString("\n" + helpView)
+
+	queue := m.queueView()
+	leftWidth := m.leftPaneWidth(queue)
+	leftBorderColor := lipgloss.Color("#89dceb")
+	if m.focus == focusTracks {
+		leftBorderColor = lipgloss.Color("#f5c2e7")
+	}
+	left := lipgloss.NewStyle().
+		Width(leftWidth).
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(leftBorderColor).
+		Padding(0, 1).
+		Render(truncateBlock(leftPane.String(), leftWidth))
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, left, strings.Repeat(" ", queuePanelGap), queue)
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		// Global control board hotkeys are always handled first.
 		switch {
-		case key.Matches(msg, m.help.Keys().Quit):
+		case key.Matches(msg, m.help.Keys().Global.Quit):
 			if err := m.stopPlayback(); err != nil {
 				log.Printf("error closing active track: %v", err)
 			}
 			return m, tea.Quit
-		case key.Matches(msg, m.help.Keys().PlayPause):
-			if m.playing.Control.Ctrl == nil {
+		case key.Matches(msg, m.help.Keys().Global.PlayPause):
+			if !m.isPlaying() {
+				if len(m.queue) == 0 {
+					m.enqueueSelected()
+				}
+				if cmd, ok := m.playNextQueuedCmd(); ok {
+					return m, cmd
+				}
 				return m, nil
 			}
 			speaker.Lock()
@@ -156,7 +347,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			speaker.Unlock()
 			return m, nil
 
-		case key.Matches(msg, m.help.Keys().Loop):
+		case key.Matches(msg, m.help.Keys().Global.FocusNext):
+			if m.focus == focusQueue {
+				m.focus = focusTracks
+			} else {
+				m.focus = focusQueue
+				m.clampQueueCursor()
+			}
+			return m, nil
+
+		case key.Matches(msg, m.help.Keys().Global.Loop):
 			if m.playing.Control.Ctrl == nil {
 				return m, nil
 			}
@@ -171,18 +371,48 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = nil
 			return m, nil
 
-		case key.Matches(msg, m.help.Keys().KeyHelp):
+		case key.Matches(msg, m.help.Keys().Global.KeyHelp):
 			m.help.ToggleShowHelp()
 			return m, nil
+		}
 
+		// Focused component hotkeys are handled after globals.
+		switch m.focus {
+		case focusQueue:
+			switch {
+			case key.Matches(msg, m.help.Keys().Queue.DequeueSelected):
+				m.dequeueSelected()
+				return m, nil
+			case key.Matches(msg, m.help.Keys().Queue.Down):
+				m.moveQueueCursor(1)
+				return m, nil
+			case key.Matches(msg, m.help.Keys().Queue.Up):
+				m.moveQueueCursor(-1)
+				return m, nil
+			default:
+				// Ignore unbound keys while queue is focused.
+				return m, nil
+			}
+		case focusTracks:
+			if key.Matches(msg, m.help.Keys().Tracks.QueueSelected) {
+				m.enqueueSelected()
+				return m, nil
+			}
+		}
+
+		if m.focus == focusQueue {
+			return m, nil
 		}
 	case errorMsg:
 		m.err = msg
 		return m, nil
 
 	case dirLoadedMsg:
-		m.loadingDirectory = false
+		m.tracks.loadingDirectory = false
 		return m, nil
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
 
 	case loadedTrackMsg:
 		speaker.Clear()
@@ -193,6 +423,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		m.playing = msg.track
+		m.playingPath = msg.path
 		m.playing.Control.Paused = false
 		m.err = nil
 
@@ -202,34 +433,25 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tickCmd()
 
 	case tickMsg:
-		if m.playing.Control.Ctrl == nil || m.playing.Control.Source == nil {
+		if !m.isPlaying() {
 			return m, nil
 		}
 		if !m.playing.Control.Loop && m.playing.Percent() >= 1.0 {
-			m.playing.Control.Paused = false
+			if cmd, ok := m.playNextQueuedCmd(); ok {
+				return m, cmd
+			}
+
+			if err := m.stopPlayback(); err != nil {
+				m.err = err
+			}
 			return m, nil
 		}
 		return m, tickCmd()
 
 	}
 
-	if keyMsg, ok := msg.(tea.KeyMsg); ok && m.loadingDirectory {
-		if key.Matches(keyMsg, m.filepicker.KeyMap.Open) ||
-			key.Matches(keyMsg, m.filepicker.KeyMap.Select) ||
-			key.Matches(keyMsg, m.filepicker.KeyMap.Back) {
-			return m, nil
-		}
-	}
-
-	prevDir := m.filepicker.CurrentDirectory
-	var cmd tea.Cmd
-	m.filepicker, cmd = m.filepicker.Update(msg)
-	if m.filepicker.CurrentDirectory != prevDir && cmd != nil {
-		m.loadingDirectory = true
-		cmd = tea.Sequence(cmd, func() tea.Msg { return dirLoadedMsg{} })
-	}
-
-	if didSelect, path := m.filepicker.DidSelectFile(msg); didSelect {
+	cmd, path, didSelect := m.tracks.Update(msg)
+	if didSelect {
 		if strings.HasSuffix(strings.ToLower(path), ".mp3") {
 			return m, m.playSongCmd(path)
 		}
@@ -252,7 +474,7 @@ func main() {
 	var sr beep.SampleRate = 48000
 
 	m := model{
-		filepicker: fp,
+		tracks:     newTracksComponent(fp),
 		sampleRate: sr,
 		help:       help.NewDefault(),
 	}

--- a/cmd/player/main_test.go
+++ b/cmd/player/main_test.go
@@ -1,0 +1,291 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/bubbles/filepicker"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/gopxl/beep/v2"
+	"github.com/kjloveless/tmp/internal/help"
+	"github.com/kjloveless/tmp/internal/track"
+)
+
+type testStream struct {
+	len      int
+	position int
+	closed   bool
+}
+
+func (s *testStream) Stream(samples [][2]float64) (int, bool) {
+	return 0, false
+}
+
+func (s *testStream) Err() error {
+	return nil
+}
+
+func (s *testStream) Len() int {
+	return s.len
+}
+
+func (s *testStream) Position() int {
+	return s.position
+}
+
+func (s *testStream) Seek(p int) error {
+	s.position = p
+	return nil
+}
+
+func (s *testStream) Close() error {
+	s.closed = true
+	return nil
+}
+
+func TestEnqueueSelectedQueuesHighlightedFile(t *testing.T) {
+	dir := t.TempDir()
+	playingPath := filepath.Join(dir, "a.mp3")
+	selectedPath := filepath.Join(dir, "b.mp3")
+
+	for _, path := range []string{playingPath, selectedPath} {
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatalf("write fixture %s: %v", path, err)
+		}
+	}
+
+	fp := filepicker.New()
+	fp.CurrentDirectory = dir
+	fp.AllowedTypes = []string{".mp3"}
+
+	m := model{
+		tracks:      newTracksComponent(fp),
+		playing:     track.Track{Title: filepath.Base(playingPath)},
+		playingPath: playingPath,
+	}
+	m.tracks.syncSelection(tea.KeyMsg{Type: tea.KeyDown}, fp.CurrentDirectory)
+	m.enqueueSelected()
+
+	if len(m.queue) != 1 {
+		t.Fatalf("queue length = %d, want 1", len(m.queue))
+	}
+	if m.queue[0].path != selectedPath {
+		t.Fatalf("queued path = %q, want %q", m.queue[0].path, selectedPath)
+	}
+	if m.queue[0].title != filepath.Base(selectedPath) {
+		t.Fatalf("queued title = %q, want %q", m.queue[0].title, filepath.Base(selectedPath))
+	}
+}
+
+func TestQueueSelectedOnlyQueuesWhenIdle(t *testing.T) {
+	dir := t.TempDir()
+	selectedPath := filepath.Join(dir, "a.mp3")
+	if err := os.WriteFile(selectedPath, nil, 0o600); err != nil {
+		t.Fatalf("write fixture %s: %v", selectedPath, err)
+	}
+
+	fp := filepicker.New()
+	fp.CurrentDirectory = dir
+	fp.AllowedTypes = []string{".mp3"}
+
+	m := model{
+		tracks: newTracksComponent(fp),
+		help:   help.NewDefault(),
+	}
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	got := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("queueing while idle returned playback command, want queue-only behavior")
+	}
+	if len(got.queue) != 1 {
+		t.Fatalf("queue length = %d, want 1", len(got.queue))
+	}
+	if got.queue[0].path != selectedPath {
+		t.Fatalf("queued path = %q, want %q", got.queue[0].path, selectedPath)
+	}
+}
+
+func TestPlayPauseStartsQueuedTrackWhenIdle(t *testing.T) {
+	m := model{
+		help: help.NewDefault(),
+		queue: []queuedTrack{{
+			path:  "next.mp3",
+			title: "next.mp3",
+		}},
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	got := updated.(model)
+
+	if cmd == nil {
+		t.Fatal("play/pause with queued item returned nil command, want playback command")
+	}
+	if len(got.queue) != 0 {
+		t.Fatalf("queue length = %d, want 0 after starting queued track", len(got.queue))
+	}
+}
+
+func TestPlayPauseQueuesAndStartsSelectedTrackWhenIdleQueueEmpty(t *testing.T) {
+	dir, err := filepath.Abs("../../sounds/mp3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	selectedPath := filepath.Join(dir, "break.mp3")
+
+	fp := filepicker.New()
+	fp.CurrentDirectory = dir
+	fp.AllowedTypes = []string{".mp3"}
+
+	m := model{
+		tracks: newTracksComponent(fp),
+		help:   help.NewDefault(),
+	}
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	got := updated.(model)
+
+	if cmd == nil {
+		t.Fatal("play/pause with empty queue returned nil command, want selected-track playback command")
+	}
+	if len(got.queue) != 0 {
+		t.Fatalf("queue length = %d, want 0 after starting selected track", len(got.queue))
+	}
+
+	msg := cmd()
+	loaded, ok := msg.(loadedTrackMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want loadedTrackMsg", msg)
+	}
+	t.Cleanup(func() {
+		if err := loaded.track.Control.Source.Close(); err != nil {
+			t.Fatalf("close loaded track: %v", err)
+		}
+	})
+	if loaded.path != selectedPath {
+		t.Fatalf("loaded path = %q, want %q", loaded.path, selectedPath)
+	}
+}
+
+func TestQueueFocusDequeueKeyRemovesFirstQueuedTrackByDefault(t *testing.T) {
+	m := model{
+		help: help.NewDefault(),
+		queue: []queuedTrack{
+			{path: "first.mp3", title: "first.mp3"},
+			{path: "second.mp3", title: "second.mp3"},
+		},
+	}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	focused := updated.(model)
+
+	updated, cmd := focused.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	got := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("dequeue returned command, want nil")
+	}
+	if len(got.queue) != 1 {
+		t.Fatalf("queue length = %d, want 1", len(got.queue))
+	}
+	if got.queue[0].path != "second.mp3" {
+		t.Fatalf("remaining queued path = %q, want second.mp3", got.queue[0].path)
+	}
+}
+
+func TestQueueFocusDequeueRemovesSelectedQueuedTrack(t *testing.T) {
+	m := model{
+		help: help.NewDefault(),
+		queue: []queuedTrack{
+			{path: "first.mp3", title: "first.mp3"},
+			{path: "second.mp3", title: "second.mp3"},
+			{path: "third.mp3", title: "third.mp3"},
+		},
+	}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	focused := updated.(model)
+	if focused.focus != focusQueue {
+		t.Fatalf("focus = %v, want queue focus", focused.focus)
+	}
+
+	updated, _ = focused.Update(tea.KeyMsg{Type: tea.KeyDown})
+	selected := updated.(model)
+	if selected.queueCursor != 1 {
+		t.Fatalf("queue cursor = %d, want 1", selected.queueCursor)
+	}
+
+	updated, cmd := selected.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	got := updated.(model)
+	if cmd != nil {
+		t.Fatal("dequeue selected returned command, want nil")
+	}
+	if len(got.queue) != 2 {
+		t.Fatalf("queue length = %d, want 2", len(got.queue))
+	}
+	if got.queue[0].path != "first.mp3" || got.queue[1].path != "third.mp3" {
+		t.Fatalf("queue paths = [%s %s], want [first.mp3 third.mp3]", got.queue[0].path, got.queue[1].path)
+	}
+	if got.queueCursor != 1 {
+		t.Fatalf("queue cursor = %d, want 1 after removing selected item", got.queueCursor)
+	}
+}
+
+func TestQueueViewShowsPlayingTrackAndKeepsFixedWidth(t *testing.T) {
+	empty := (&model{}).queueView()
+	withLongPlaying := (&model{
+		playing: track.Track{Title: strings.Repeat("a", queuePanelContentWidth*2)},
+	}).queueView()
+	withQueue := (&model{
+		queue: []queuedTrack{{
+			path:  "next.mp3",
+			title: strings.Repeat("b", queuePanelContentWidth*2),
+		}},
+	}).queueView()
+
+	emptyWidth := lipgloss.Width(empty)
+	if got := lipgloss.Width(withLongPlaying); got != emptyWidth {
+		t.Fatalf("playing queue panel width = %d, want %d", got, emptyWidth)
+	}
+	if got := lipgloss.Width(withQueue); got != emptyWidth {
+		t.Fatalf("queued panel width = %d, want %d", got, emptyWidth)
+	}
+	if !strings.Contains(withLongPlaying, "Playing") {
+		t.Fatal("queue panel with active track does not show Playing section")
+	}
+}
+
+func TestTruncateBlockKeepsEveryLineWithinWidth(t *testing.T) {
+	const width = 10
+	got := truncateBlock("short\n"+strings.Repeat("x", width*2), width)
+	for _, line := range strings.Split(got, "\n") {
+		if lineWidth := lipgloss.Width(line); lineWidth > width {
+			t.Fatalf("line width = %d, want <= %d for %q", lineWidth, width, line)
+		}
+	}
+}
+
+func TestFinishedTrackStartsNextQueuedTrack(t *testing.T) {
+	source := &testStream{len: 100, position: 100}
+	format := beep.Format{SampleRate: 100, NumChannels: 2, Precision: 2}
+	m := model{
+		playing: track.New(source, &format, "done.mp3", time.Second),
+		queue: []queuedTrack{{
+			path:  "next.mp3",
+			title: "next.mp3",
+		}},
+	}
+
+	updated, cmd := m.Update(tickMsg(time.Now()))
+	got := updated.(model)
+
+	if cmd == nil {
+		t.Fatal("finished track with queued item returned nil command, want playback command")
+	}
+	if len(got.queue) != 0 {
+		t.Fatalf("queue length = %d, want 0 after dequeuing next track", len(got.queue))
+	}
+}

--- a/cmd/player/main_test.go
+++ b/cmd/player/main_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/bubbles/filepicker"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/gopxl/beep/v2"
 	"github.com/kjloveless/tmp/internal/help"
 	"github.com/kjloveless/tmp/internal/track"
@@ -234,6 +235,45 @@ func TestQueueFocusDequeueRemovesSelectedQueuedTrack(t *testing.T) {
 	}
 }
 
+func TestFocusNextIgnoresEmptyQueue(t *testing.T) {
+	m := model{
+		help: help.NewDefault(),
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	got := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("focus toggle returned command, want nil")
+	}
+	if got.focus != focusTracks {
+		t.Fatalf("focus = %v, want tracks when queue is empty", got.focus)
+	}
+	if focus := got.helpFocus(); focus != help.FocusTracks {
+		t.Fatalf("help focus = %v, want tracks when queue is empty", focus)
+	}
+}
+
+func TestDequeueLastTrackReturnsFocusToTracks(t *testing.T) {
+	m := model{
+		help:  help.NewDefault(),
+		focus: focusQueue,
+		queue: []queuedTrack{
+			{path: "last.mp3", title: "last.mp3"},
+		},
+	}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	got := updated.(model)
+
+	if len(got.queue) != 0 {
+		t.Fatalf("queue length = %d, want 0", len(got.queue))
+	}
+	if got.focus != focusTracks {
+		t.Fatalf("focus = %v, want tracks after emptying queue", got.focus)
+	}
+}
+
 func TestQueueViewShowsPlayingTrackAndKeepsFixedWidth(t *testing.T) {
 	empty := (&model{}).queueView()
 	withLongPlaying := (&model{
@@ -264,6 +304,98 @@ func TestTruncateBlockKeepsEveryLineWithinWidth(t *testing.T) {
 	for _, line := range strings.Split(got, "\n") {
 		if lineWidth := lipgloss.Width(line); lineWidth > width {
 			t.Fatalf("line width = %d, want <= %d for %q", lineWidth, width, line)
+		}
+	}
+}
+
+func TestPlayerHelpViewSpansWindowWidth(t *testing.T) {
+	const width = 96
+	m := model{
+		width: width,
+		help:  help.NewDefault(),
+	}
+
+	got := m.playerHelpView()
+	if gotWidth := lipgloss.Width(got); gotWidth != width {
+		t.Fatalf("player/help panel width = %d, want %d", gotWidth, width)
+	}
+	if !strings.Contains(got, "Select an MP3 file to play.") {
+		t.Fatal("player/help panel does not include idle player status")
+	}
+	if !strings.Contains(got, "play/pause") {
+		t.Fatal("player/help panel does not include contextual help")
+	}
+}
+
+func TestViewFitsWithinWindowHeight(t *testing.T) {
+	const (
+		width  = 80
+		height = 24
+	)
+	fp := filepicker.New()
+	fp.AutoHeight = false
+	fp.Height = height
+
+	m := model{
+		width:  width,
+		height: height,
+		tracks: newTracksComponent(fp),
+		help:   help.NewDefault(),
+	}
+
+	got := m.View()
+	if gotHeight := lipgloss.Height(got); gotHeight > height {
+		t.Fatalf("view height = %d, want <= %d", gotHeight, height)
+	}
+	if !strings.HasPrefix(got, "╭") {
+		t.Fatalf("view should start with top border, got %q", strings.Split(got, "\n")[0])
+	}
+
+	bottom := m.playerHelpView()
+	topHeight := m.topPaneHeight(bottom)
+	lines := strings.Split(got, "\n")
+	hasTrackBottomBorder := false
+	for _, line := range lines[:min(topHeight, len(lines))] {
+		if strings.HasPrefix(line, "╰") {
+			hasTrackBottomBorder = true
+			break
+		}
+	}
+	if !hasTrackBottomBorder {
+		t.Fatal("top pane should include the tracks bottom border before the bottom player/help panel")
+	}
+}
+
+func TestViewFitsWithinWindowWidthWithQueue(t *testing.T) {
+	const height = 24
+
+	for _, width := range []int{40, 60, 80} {
+		fp := filepicker.New()
+
+		m := model{
+			width:  width,
+			height: height,
+			tracks: newTracksComponent(fp),
+			help:   help.NewDefault(),
+			queue: []queuedTrack{
+				{path: "first.mp3", title: strings.Repeat("first-", 10) + ".mp3"},
+				{path: "second.mp3", title: strings.Repeat("second-", 10) + ".mp3"},
+			},
+		}
+
+		got := m.View()
+		if gotWidth := lipgloss.Width(got); gotWidth > width {
+			t.Fatalf("view width = %d, want <= %d", gotWidth, width)
+		}
+		for i, line := range strings.Split(got, "\n") {
+			if lineWidth := lipgloss.Width(line); lineWidth > width {
+				t.Fatalf("line %d width = %d, want <= %d for %q", i, lineWidth, width, line)
+			}
+		}
+
+		firstLine := ansi.Strip(strings.Split(got, "\n")[0])
+		if !strings.HasSuffix(firstLine, "╮") {
+			t.Fatalf("queue panel top border should be visible at right edge for width %d, got %q", width, firstLine)
 		}
 	}
 }

--- a/cmd/player/tracks.go
+++ b/cmd/player/tracks.go
@@ -30,6 +30,15 @@ func (tc tracksComponent) View() string {
 	return tc.picker.View()
 }
 
+func (tc tracksComponent) ViewWithHeight(height int) string {
+	if height < 0 {
+		height = 0
+	}
+	tc.picker.AutoHeight = false
+	tc.picker.SetHeight(height)
+	return tc.picker.View()
+}
+
 func (tc tracksComponent) pickerEntries() ([]os.DirEntry, error) {
 	entries, err := os.ReadDir(tc.picker.CurrentDirectory)
 	if err != nil {

--- a/cmd/player/tracks.go
+++ b/cmd/player/tracks.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/filepicker"
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type tracksComponent struct {
+	picker           filepicker.Model
+	selected         int
+	stack            []int
+	loadingDirectory bool
+}
+
+func newTracksComponent(fp filepicker.Model) tracksComponent {
+	return tracksComponent{picker: fp}
+}
+
+func (tc tracksComponent) Init() tea.Cmd {
+	return tc.picker.Init()
+}
+
+func (tc tracksComponent) View() string {
+	return tc.picker.View()
+}
+
+func (tc tracksComponent) pickerEntries() ([]os.DirEntry, error) {
+	entries, err := os.ReadDir(tc.picker.CurrentDirectory)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].IsDir() == entries[j].IsDir() {
+			return entries[i].Name() < entries[j].Name()
+		}
+		return entries[i].IsDir()
+	})
+
+	if tc.picker.ShowHidden {
+		return entries, nil
+	}
+
+	visible := entries[:0]
+	for _, entry := range entries {
+		hidden, _ := filepicker.IsHidden(entry.Name())
+		if !hidden {
+			visible = append(visible, entry)
+		}
+	}
+	return visible, nil
+}
+
+func (tc tracksComponent) canSelectPath(path string) bool {
+	if len(tc.picker.AllowedTypes) == 0 {
+		return true
+	}
+
+	for _, ext := range tc.picker.AllowedTypes {
+		if strings.HasSuffix(path, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+func isDirectory(entry os.DirEntry, path string) bool {
+	info, err := entry.Info()
+	if err != nil {
+		return entry.IsDir()
+	}
+
+	if info.Mode()&os.ModeSymlink == 0 {
+		return entry.IsDir()
+	}
+
+	target, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return entry.IsDir()
+	}
+	targetInfo, err := os.Stat(target)
+	if err != nil {
+		return entry.IsDir()
+	}
+	return targetInfo.IsDir()
+}
+
+func (tc tracksComponent) selectedFilePath() (string, bool) {
+	entries, err := tc.pickerEntries()
+	if err != nil || len(entries) == 0 || tc.selected < 0 || tc.selected >= len(entries) {
+		return "", false
+	}
+
+	entry := entries[tc.selected]
+	path := filepath.Join(tc.picker.CurrentDirectory, entry.Name())
+	if isDirectory(entry, path) || !tc.canSelectPath(path) {
+		return "", false
+	}
+	return path, true
+}
+
+func (tc *tracksComponent) clampSelected() {
+	entries, err := tc.pickerEntries()
+	if err != nil || len(entries) == 0 {
+		tc.selected = 0
+		return
+	}
+
+	switch {
+	case tc.selected < 0:
+		tc.selected = 0
+	case tc.selected >= len(entries):
+		tc.selected = len(entries) - 1
+	}
+}
+
+func (tc *tracksComponent) syncSelection(msg tea.Msg, previousDirectory string) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		tc.clampSelected()
+		return
+	}
+
+	if tc.picker.CurrentDirectory != previousDirectory {
+		if key.Matches(keyMsg, tc.picker.KeyMap.Back) {
+			if len(tc.stack) > 0 {
+				last := len(tc.stack) - 1
+				tc.selected = tc.stack[last]
+				tc.stack = tc.stack[:last]
+			} else {
+				tc.selected = 0
+			}
+		} else {
+			tc.stack = append(tc.stack, tc.selected)
+			tc.selected = 0
+		}
+		tc.clampSelected()
+		return
+	}
+
+	entries, err := tc.pickerEntries()
+	if err != nil || len(entries) == 0 {
+		tc.selected = 0
+		return
+	}
+
+	switch {
+	case key.Matches(keyMsg, tc.picker.KeyMap.GoToTop):
+		tc.selected = 0
+	case key.Matches(keyMsg, tc.picker.KeyMap.GoToLast):
+		tc.selected = len(entries) - 1
+	case key.Matches(keyMsg, tc.picker.KeyMap.Down):
+		tc.selected++
+	case key.Matches(keyMsg, tc.picker.KeyMap.Up):
+		tc.selected--
+	case key.Matches(keyMsg, tc.picker.KeyMap.PageDown):
+		tc.selected += tc.picker.Height
+	case key.Matches(keyMsg, tc.picker.KeyMap.PageUp):
+		tc.selected -= tc.picker.Height
+	}
+	tc.clampSelected()
+}
+
+func (tc *tracksComponent) Update(msg tea.Msg) (tea.Cmd, string, bool) {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok && tc.loadingDirectory {
+		if key.Matches(keyMsg, tc.picker.KeyMap.Open) ||
+			key.Matches(keyMsg, tc.picker.KeyMap.Select) ||
+			key.Matches(keyMsg, tc.picker.KeyMap.Back) {
+			return nil, "", false
+		}
+	}
+
+	prevDir := tc.picker.CurrentDirectory
+	var cmd tea.Cmd
+	tc.picker, cmd = tc.picker.Update(msg)
+	tc.syncSelection(msg, prevDir)
+	if tc.picker.CurrentDirectory != prevDir && cmd != nil {
+		tc.loadingDirectory = true
+		cmd = tea.Sequence(cmd, func() tea.Msg { return dirLoadedMsg{} })
+	}
+
+	didSelect, path := tc.picker.DidSelectFile(msg)
+	return cmd, path, didSelect
+}

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -1,6 +1,9 @@
 package help
 
 import (
+	"fmt"
+	"log"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/help"
@@ -8,41 +11,99 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-var DefaultKeyMap = KeyMap{
-	PlayPause: key.NewBinding(
-		key.WithKeys("p"),
-		key.WithHelp("p", "resume/pause"),
-	),
-  Loop: key.NewBinding(
-    key.WithKeys("l"),
-    key.WithHelp("l", "loop"),
-  ),
-	Quit: key.NewBinding(
-		key.WithKeys("q", "ctrl+c"),
-		key.WithHelp("q/ctrl+c", "quit"),
-	),
+type FocusArea string
 
-	KeyHelp: key.NewBinding(
-		key.WithKeys("?"),
-		key.WithHelp("?", "help"),
-	),
+const (
+	FocusTracks FocusArea = "tracks"
+	FocusQueue  FocusArea = "queue"
+)
+
+type GlobalKeyMap struct {
+	PlayPause key.Binding
+	FocusNext key.Binding
+	Loop      key.Binding
+	Quit      key.Binding
+	KeyHelp   key.Binding
+}
+
+type TracksKeyMap struct {
+	QueueSelected key.Binding
+}
+
+type QueueKeyMap struct {
+	DequeueSelected key.Binding
+	Up              key.Binding
+	Down            key.Binding
+}
+
+type KeyMap struct {
+	Global GlobalKeyMap
+	Tracks TracksKeyMap
+	Queue  QueueKeyMap
+}
+
+var DefaultKeyMap = KeyMap{
+	Global: GlobalKeyMap{
+		PlayPause: key.NewBinding(
+			key.WithKeys("p"),
+			key.WithHelp("p", "play/pause"),
+		),
+		FocusNext: key.NewBinding(
+			key.WithKeys("tab"),
+			key.WithHelp("tab", "switch focus"),
+		),
+		Loop: key.NewBinding(
+			key.WithKeys("l"),
+			key.WithHelp("l", "loop"),
+		),
+		Quit: key.NewBinding(
+			key.WithKeys("esc", "ctrl+c"),
+			key.WithHelp("esc/ctrl+c", "quit"),
+		),
+		KeyHelp: key.NewBinding(
+			key.WithKeys("?"),
+			key.WithHelp("?", "help"),
+		),
+	},
+	Tracks: TracksKeyMap{
+		QueueSelected: key.NewBinding(
+			key.WithKeys("q"),
+			key.WithHelp("q", "queue selected"),
+		),
+	},
+	Queue: QueueKeyMap{
+		DequeueSelected: key.NewBinding(
+			key.WithKeys("d"),
+			key.WithHelp("d", "dequeue selected"),
+		),
+		Up: key.NewBinding(
+			key.WithKeys("up", "k"),
+			key.WithHelp("↑/k", "queue up"),
+		),
+		Down: key.NewBinding(
+			key.WithKeys("down", "j"),
+			key.WithHelp("↓/j", "queue down"),
+		),
+	},
 }
 
 type Styles struct {
-	Title     lipgloss.Style
-	Key       lipgloss.Style
-	Desc      lipgloss.Style
-	Row       lipgloss.Style
-	Panel     lipgloss.Style
-	Separator string
+	Title        lipgloss.Style
+	SectionTitle lipgloss.Style
+	Key          lipgloss.Style
+	Desc         lipgloss.Style
+	Row          lipgloss.Style
+	Panel        lipgloss.Style
+	Separator    string
 }
 
 func DefaultStyles() Styles {
 	return Styles{
-		Title: lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#89dceb")),
-		Key:   lipgloss.NewStyle().Foreground(lipgloss.Color("#f5c2e7")).Bold(true),
-		Desc:  lipgloss.NewStyle().Foreground(lipgloss.Color("#a6adc8")),
-		Row:   lipgloss.NewStyle().Padding(0, 1),
+		Title:        lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#89dceb")),
+		SectionTitle: lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#f9e2af")),
+		Key:          lipgloss.NewStyle().Foreground(lipgloss.Color("#f5c2e7")).Bold(true),
+		Desc:         lipgloss.NewStyle().Foreground(lipgloss.Color("#a6adc8")),
+		Row:          lipgloss.NewStyle().Padding(0, 1),
 		Panel: lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(lipgloss.Color("#94e2d5")).
@@ -51,80 +112,6 @@ func DefaultStyles() Styles {
 	}
 }
 
-func (hu HelpUI) listEntries(s Styles) []string {
-	var out []string
-	for _, group := range hu.keys.FullHelp() {
-		for _, b := range group {
-			h := b.Help()
-			k := h.Key
-			d := h.Desc
-			if k == "" && d == "" {
-				continue
-			}
-			row := lipgloss.JoinHorizontal(
-				lipgloss.Left,
-				s.Key.Render(k),
-				s.Separator,
-				s.Desc.Render(d),
-			)
-			out = append(out, s.Row.Render(row))
-		}
-	}
-	return out
-}
-
-func (hu HelpUI) ListView() string {
-	s := DefaultStyles()
-
-	entries := hu.listEntries(s)
-	if len(entries) == 0 {
-		return ""
-	}
-
-	w := hu.model.Width
-	if w <= 0 {
-		w = 80
-	}
-
-	half := (len(entries) + 1) / 2
-	left := entries[:half]
-	right := entries[half:]
-
-	colGap := 4
-	colWidth := (w - colGap - 2*s.Panel.GetHorizontalBorderSize() - 2*s.Panel.GetHorizontalPadding()) / 2
-	if colWidth < 20 {
-		body := lipgloss.NewStyle().Width(w).Render(strings.Join(entries, "\n"))
-		content := lipgloss.JoinVertical(lipgloss.Left, s.Title.Render("Keyboard shortcuts"), body)
-		return s.Panel.Width(w).Render(content)
-	}
-
-	leftCol := lipgloss.NewStyle().Width(colWidth).Render(strings.Join(left, "\n"))
-	rightCol := lipgloss.NewStyle().Width(colWidth).Render(strings.Join(right, "\n"))
-	rows := lipgloss.JoinHorizontal(lipgloss.Top, leftCol, strings.Repeat(" ", colGap), rightCol)
-
-	content := lipgloss.JoinVertical(
-		lipgloss.Left,
-		s.Title.Render("Keyboard shortcuts"),
-		rows,
-	)
-
-	return s.Panel.Width(w).Render(content)
-}
-
-func (hu HelpUI) View() string {
-	return hu.model.View(hu.keys)
-}
-
-func (hu HelpUI) Keys() KeyMap {
-	return hu.keys
-}
-
-type KeyMap struct {
-	PlayPause key.Binding
-  Loop      key.Binding
-	Quit      key.Binding
-	KeyHelp   key.Binding
-}
 type HelpUI struct {
 	model    help.Model
 	keys     KeyMap
@@ -132,10 +119,19 @@ type HelpUI struct {
 }
 
 func NewHelpUI(keys KeyMap) HelpUI {
+	validateOrPanic(keys)
 	return HelpUI{
 		model: help.New(),
 		keys:  keys,
 	}
+}
+
+func NewDefault() HelpUI {
+	return NewHelpUI(DefaultKeyMap)
+}
+
+func (hu HelpUI) Keys() KeyMap {
+	return hu.keys
 }
 
 func (hu HelpUI) GetshowHelp() bool {
@@ -146,19 +142,108 @@ func (hu *HelpUI) ToggleShowHelp() {
 	hu.showHelp = !hu.showHelp
 }
 
-func NewDefault() HelpUI {
-	return NewHelpUI(DefaultKeyMap)
+type displayKeyMap struct {
+	short []key.Binding
+	full  [][]key.Binding
 }
 
-func (k KeyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.PlayPause, k.Loop, k.Quit, k.KeyHelp}
-}
+func (d displayKeyMap) ShortHelp() []key.Binding  { return d.short }
+func (d displayKeyMap) FullHelp() [][]key.Binding { return d.full }
 
-func (k KeyMap) FullHelp() [][]key.Binding {
-	return [][]key.Binding{
-		{k.PlayPause},
-    {k.Loop},
-		{k.Quit},
-		{k.KeyHelp},
+func (hu HelpUI) contextualBindings(focus FocusArea) []key.Binding {
+	bindings := []key.Binding{
+		hu.keys.Global.PlayPause,
+		hu.keys.Global.FocusNext,
+		hu.keys.Global.Loop,
+		hu.keys.Global.Quit,
+		hu.keys.Global.KeyHelp,
 	}
+	if focus == FocusQueue {
+		bindings = append(bindings, hu.keys.Queue.Up, hu.keys.Queue.Down, hu.keys.Queue.DequeueSelected)
+	} else {
+		bindings = append(bindings, hu.keys.Tracks.QueueSelected)
+	}
+	return bindings
+}
+
+func (hu HelpUI) View(focus FocusArea) string {
+	short := hu.contextualBindings(focus)
+	full := make([][]key.Binding, 0, len(short))
+	for _, b := range short {
+		full = append(full, []key.Binding{b})
+	}
+	return hu.model.View(displayKeyMap{short: short, full: full})
+}
+
+func (hu HelpUI) ListView(focus FocusArea) string {
+	s := DefaultStyles()
+	w := hu.model.Width
+	if w <= 0 {
+		w = 80
+	}
+
+	sectionTitle := func(name string, active bool) string {
+		if active {
+			name += " (focused)"
+		}
+		return s.SectionTitle.Render(name)
+	}
+
+	renderBindings := func(bindings []key.Binding) string {
+		rows := make([]string, 0, len(bindings))
+		for _, b := range bindings {
+			h := b.Help()
+			if h.Key == "" && h.Desc == "" {
+				continue
+			}
+			row := lipgloss.JoinHorizontal(lipgloss.Left, s.Key.Render(h.Key), s.Separator, s.Desc.Render(h.Desc))
+			rows = append(rows, s.Row.Render(row))
+		}
+		return strings.Join(rows, "\n")
+	}
+
+	globalBindings := []key.Binding{hu.keys.Global.PlayPause, hu.keys.Global.FocusNext, hu.keys.Global.Loop, hu.keys.Global.Quit, hu.keys.Global.KeyHelp}
+	tracksBindings := []key.Binding{hu.keys.Tracks.QueueSelected}
+	queueBindings := []key.Binding{hu.keys.Queue.Up, hu.keys.Queue.Down, hu.keys.Queue.DequeueSelected}
+
+	content := lipgloss.JoinVertical(
+		lipgloss.Left,
+		s.Title.Render("Keyboard shortcuts"),
+		"",
+		sectionTitle("Global controls", false),
+		renderBindings(globalBindings),
+		"",
+		sectionTitle("Tracks controls", focus == FocusTracks),
+		renderBindings(tracksBindings),
+		"",
+		sectionTitle("Queue controls", focus == FocusQueue),
+		renderBindings(queueBindings),
+	)
+
+	return s.Panel.Width(w).Render(content)
+}
+
+func validateOrPanic(keys KeyMap) {
+	assertUnique := func(scope string, bindings []key.Binding) {
+		seen := make(map[string]string)
+		for _, b := range bindings {
+			h := b.Help()
+			if h.Key == "" {
+				continue
+			}
+			for _, k := range b.Keys() {
+				if prev, exists := seen[k]; exists {
+					msg := fmt.Sprintf("duplicate hotkey %q in %s: %s and %s", k, scope, prev, h.Desc)
+					fmt.Fprintln(os.Stdout, msg)
+					log.Print(msg)
+					panic(msg)
+				}
+				seen[k] = h.Desc
+			}
+		}
+	}
+
+	assertUnique("global", []key.Binding{keys.Global.PlayPause, keys.Global.FocusNext, keys.Global.Loop, keys.Global.Quit, keys.Global.KeyHelp})
+	assertUnique("tracks", []key.Binding{keys.Tracks.QueueSelected})
+	assertUnique("queue", []key.Binding{keys.Queue.Up, keys.Queue.Down, keys.Queue.DequeueSelected})
 }

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -78,11 +78,11 @@ var DefaultKeyMap = KeyMap{
 		),
 		Up: key.NewBinding(
 			key.WithKeys("up", "k"),
-			key.WithHelp("↑/k", "queue up"),
+			key.WithHelp("↑/k", "move up"),
 		),
 		Down: key.NewBinding(
 			key.WithKeys("down", "j"),
-			key.WithHelp("↓/j", "queue down"),
+			key.WithHelp("↓/j", "move down"),
 		),
 	},
 }
@@ -159,7 +159,7 @@ func (hu HelpUI) contextualBindings(focus FocusArea) []key.Binding {
 		hu.keys.Global.KeyHelp,
 	}
 	if focus == FocusQueue {
-		bindings = append(bindings, hu.keys.Queue.Up, hu.keys.Queue.Down, hu.keys.Queue.DequeueSelected)
+		bindings = append(bindings, hu.keys.Queue.DequeueSelected)
 	} else {
 		bindings = append(bindings, hu.keys.Tracks.QueueSelected)
 	}
@@ -173,6 +173,11 @@ func (hu HelpUI) View(focus FocusArea) string {
 		full = append(full, []key.Binding{b})
 	}
 	return hu.model.View(displayKeyMap{short: short, full: full})
+}
+
+func (hu HelpUI) ViewWithWidth(focus FocusArea, width int) string {
+	hu.model.Width = width
+	return hu.View(focus)
 }
 
 func (hu HelpUI) ListView(focus FocusArea) string {

--- a/internal/help/help_test.go
+++ b/internal/help/help_test.go
@@ -1,0 +1,31 @@
+package help
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/key"
+)
+
+func TestNewHelpUIPanicsOnDuplicateScopeBindings(t *testing.T) {
+	keys := DefaultKeyMap
+	keys.Queue.Down = key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "down"))
+	keys.Queue.DequeueSelected = key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "dequeue"))
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected duplicate queue key binding panic")
+		}
+	}()
+
+	_ = NewHelpUI(keys)
+}
+
+func TestContextualBindingsIncludesFocusedComponent(t *testing.T) {
+	hu := NewDefault()
+	tracksView := hu.View(FocusTracks)
+	queueView := hu.View(FocusQueue)
+
+	if tracksView == queueView {
+		t.Fatal("contextual short help should differ between track and queue focus")
+	}
+}

--- a/internal/help/help_test.go
+++ b/internal/help/help_test.go
@@ -22,10 +22,22 @@ func TestNewHelpUIPanicsOnDuplicateScopeBindings(t *testing.T) {
 
 func TestContextualBindingsIncludesFocusedComponent(t *testing.T) {
 	hu := NewDefault()
-	tracksView := hu.View(FocusTracks)
-	queueView := hu.View(FocusQueue)
+	tracksBindings := hu.contextualBindings(FocusTracks)
+	queueBindings := hu.contextualBindings(FocusQueue)
 
-	if tracksView == queueView {
-		t.Fatal("contextual short help should differ between track and queue focus")
+	if got, want := len(queueBindings), len(tracksBindings); got != want {
+		t.Fatalf("queue help binding count = %d, want %d", got, want)
+	}
+	if desc := tracksBindings[len(tracksBindings)-1].Help().Desc; desc != "queue selected" {
+		t.Fatalf("tracks contextual action = %q, want queue selected", desc)
+	}
+	if desc := queueBindings[len(queueBindings)-1].Help().Desc; desc != "dequeue selected" {
+		t.Fatalf("queue contextual action = %q, want dequeue selected", desc)
+	}
+	for _, b := range queueBindings {
+		switch b.Help().Desc {
+		case "move up", "move down":
+			t.Fatalf("queue contextual help should only swap the action, got movement binding %q", b.Help().Desc)
+		}
 	}
 }


### PR DESCRIPTION
### Motivation
- Introduce an explicit playback queue so users can enqueue selected tracks, play through queued tracks, and remove queued items.
- Keep track browsing and queue management distinct while preserving predictable keyboard focus.
- Stabilize the TUI layout so tracks, queue, playback status, and contextual help fit within the terminal bounds.

### Description
- Add queue state and queue operations in `cmd/player/main.go`, including enqueue/dequeue helpers, automatic playback progression, and `p` behavior that enqueues and starts the selected track when idle.
- Add track/queue focus handling with `tab`; the queue is only focusable when it has items, and focus returns to tracks after the queue is emptied.
- Render a right-side queue pane with selected-item highlighting and dequeue support via `d`.
- Extract track picker behavior into `tracksComponent` in `cmd/player/tracks.go`, including selected-file tracking and explicit height rendering for the constrained top pane.
- Rework layout sizing so the bottom player/help panel spans the full width, the top row budgets height against it, and the queue pane dynamically shrinks without clipping its right border.
- Refactor contextual help to use structured key maps and show only the focused action swap: `q queue selected` for tracks and `d dequeue selected` for queue.
- Add regression coverage for queue behavior, focus behavior, layout height/width constraints, and contextual help output.

### Testing
- `go test ./cmd/player`
- `go test ./internal/help`
- `go test ./...`
- Manual smoke run with `go run ./cmd/player` to verify the tracks/queue panes and full-width bottom playback/help panel render correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da81e74cf4832f900a12d02d340802)